### PR TITLE
Descrição de um pacote de um roteiro ou tour não salva na primeira vez

### DIFF
--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -119,7 +119,7 @@ function add_packages(type) {
   var count = $('.packages-set').length;
   $('.add-packages').on('click', function(e){
       $('<div />').load('/packages/new', function(data){
-          var new_data = $(data).find('input').each(function(e){
+          var new_data = $(data).find('input, textarea').each(function(e){
               $(this).attr('name', type + '[packages_attributes][' + count  +  '][' + this.id + ']');
               if(this.id == 'included') {
                   $(this).tagsinput({


### PR DESCRIPTION
Problema resolvido adicionando na função add_packages a verificação para adicionar o name também ao textarea. Pelo fato de adicionar apenas nos inputs o campo descrição não estava sendo enviado nos parâmetros de packages_attributes.